### PR TITLE
fix: remove stepsecurity action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,16 +23,7 @@ on:
 jobs:
   run-message-transmitter-tests:
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
-
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-        with:
-          egress-policy: block
-          policy: global-allowed-endpoints-policy
-
       - name: Check out repository code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
@@ -51,16 +42,7 @@ jobs:
 
   run-token-messenger-tests:
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
-
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-        with:
-          egress-policy: block
-          policy: global-allowed-endpoints-policy
-
       - name: Check out repository code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
@@ -79,16 +61,7 @@ jobs:
 
   run-e2e-tests:
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
-
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-        with:
-          egress-policy: block
-          policy: global-allowed-endpoints-policy
-
       - name: Check out repository code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
@@ -108,16 +81,7 @@ jobs:
 
   spell-checker:
     runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
-
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
-        with:
-          egress-policy: block
-          policy: global-allowed-endpoints-policy
-
       - name: Check out repository code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 


### PR DESCRIPTION
## Summary
We are removing the use of the StepSecurity action and will be moving to GitHub Custom Hosted Runners.

## Detail
Workflow configuration simplification:

* Removed the `permissions` block (specifically `id-token: write`) from all jobs to reduce unnecessary permissions in the workflow. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL26-L35) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL54-L63) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL82-L91) [[4]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL111-L120)
* Removed the "Harden the runner" step, which used the `step-security/harden-runner` action, from all jobs to simplify the workflow and eliminate the external dependency. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL26-L35) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL54-L63) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL82-L91) [[4]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL111-L120)

## Testing

## Documentation

---

**Requested Reviewers:** @mention
